### PR TITLE
Fix kick on opening bank

### DIFF
--- a/src/main/java/net/natte/bankstorage/container/BankItemStorage.java
+++ b/src/main/java/net/natte/bankstorage/container/BankItemStorage.java
@@ -95,9 +95,12 @@ public class BankItemStorage {
     }
 
     public void markDirty() {
-        updateLockedSlotsRevision();
-        updateRevision();
-        BankStateManager.markDirty();
+        if (uuid != null) {
+            // uuid == null means we're acting as temp-storage in a client-side gui
+            updateLockedSlotsRevision();
+            updateRevision();
+            BankStateManager.markDirty();
+        }
     }
 
     public int size() {


### PR DESCRIPTION
# This PR
This PR fixes an issue encountered only when connecting to a dedicated server, where the player would get kicked when trying to open a bank.

# The Issue
The bank gui creates a `BankItemStorage` on the client, just so the client gui can sync correctly. However, this means that when the slots get changed, like when the gui is initializing, it attempts to mark the `BankPersistentState` as dirty. This causes a kick because the `BankStateManager` only gets initialized on the server.